### PR TITLE
openwebui: expose the ollama api

### DIFF
--- a/src/openwebui/proxy.json
+++ b/src/openwebui/proxy.json
@@ -1,1 +1,4 @@
-[{ "path": "/", "target": "http://localhost:3000", "ws": true }]
+[
+  { "path": "/", "target": "http://localhost:3000", "ws": true },
+  { "path": "/api", "target": "http://localhost:11434", "ws": true }
+]

--- a/src/openwebui/start-openwebui.sh
+++ b/src/openwebui/start-openwebui.sh
@@ -9,10 +9,12 @@ cd /tmp/open-webui
 
 export GPU_COUNT=`nvidia-smi -L | wc -l`
 
+RUN='./run-compose.sh --webui[port=3000] --enable-api[port=11434]'
+
 if [ $GPU_COUNT -gt 0 ]; then
   echo "Found $GPU_COUNT GPU's"
-  ./run-compose.sh --enable-gpu[count=$GPU_COUNT] --webui[port=3000] < /dev/null
+  $RUN --enable-gpu[count=$GPU_COUNT] < /dev/null
 else
   echo "No GPU's"
-  ./run-compose.sh --webui[port=3000] < /dev/null
+  $RUN < /dev/null
 fi;


### PR DESCRIPTION
I do know this exposes the API at the usual endpoint.
I'm using the ssh tunnel to the machine to access it.

I tried the api endpoint with the token, but I'm not sure if this can even work. This is what I tried:

```
$ curl -L -k -s https://[IP address]/api/generate?auth_token=[token] -d '{"model":"mistral", "system": "be brief", "prompt": "whats mount baker?", "stream": false}' 
```

Returning a short html page with a form to enter a token.

